### PR TITLE
pin alpine version rather than use :latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN cargo install --path .
 
 ###
 
-FROM alpine
+FROM alpine:3.20.1
 
 COPY --from=builder /usr/local/cargo/bin/dockerprom /dockerprom
 


### PR DESCRIPTION
Using alpine without a tag (latest) might cause unexpected breakage in the future.